### PR TITLE
Refactor/prisma schema styling

### DIFF
--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -30,7 +30,7 @@ model User {
   createdAt  DateTime     @default(now())
   updatedAt  DateTime     @updatedAt
   roles      RolesUsers[]
-  OmegaQuote OmegaQuote[]
+  omegaQuote OmegaQuote[]
 }
 
 /////////////////
@@ -135,7 +135,7 @@ model CmsImage {
   updatedAt      DateTime        @updatedAt
   imageSize      ImageSize       @default(MEDIUM)
   articleSection ArticleSection?
-  Article        Article? //Can be cover image for an article
+  article        Article? //Can be cover image for an article
 }
 
 model CmsParagraph {


### PR DESCRIPTION
The schema file is starting to become a little long. So i added a comments to divde the file into sections. They follow the style
```
//////////////////////////////
// [thing section is about] //
//////////////////////////////
```
to make them extra visible. We should of course find a way to divide the file into sub schemas, but this is a good enough solution for now. 

I also removed all the maps as it has become quite unmaintainable and tedious to enforce postgresql styling. I will look into finding an automated way for this (if I care enough).

I also fixed some instances of PascalCase being used instead of camelCase for model fields.