### PR TITLE
fix/navigation when updating and creating an article was not correct

### DIFF
--- a/src/app/news/AddNews.tsx
+++ b/src/app/news/AddNews.tsx
@@ -14,7 +14,7 @@ export default function AddNews() {
     const editModeCtx = useContext(EditModeContext)
     const handleCreate = (data?: ExpandedNewsArticle) => {
         editModeCtx?.setEditMode(true)
-        push(`/news/${data?.articleName}`)
+        push(`/news/${data?.orderPublished}/${data?.articleName}`)
     }
 
     return (

--- a/src/app/news/[...orderAndName]/EditNews.tsx
+++ b/src/app/news/[...orderAndName]/EditNews.tsx
@@ -42,7 +42,7 @@ export default function EditNews({ news, children }: PropTypes) {
                 <Form
                     action={updateAction}
                     successCallback={(data) => {
-                        push(`/news/${data?.articleName}`)
+                        push(`/news/${data?.orderPublished}/${data?.articleName}`)
                     }}
                     submitText="oppdater"
                 >


### PR DESCRIPTION
I forgot to change the navigation when updating and creating a news article in the last pr. The URL used to be news/[name], now it is news/[order]/[name] since name is no longer unique