### PR TITLE
Chore/change order published to relation

### DIFF
--- a/src/actions/images/collections/read.ts
+++ b/src/actions/images/collections/read.ts
@@ -8,6 +8,7 @@ import type { ImageCollection, Image, SpecialCollection } from '@prisma/client'
 export async function readImageCollection(
     idOrName: number | string
 ): Promise<ActionReturn<ImageCollection & {coverImage: Image | null}>> {
+    //TODO: Auth image collections on visibility or permission (if special collection)
     try {
         const collection = await prisma.imageCollection.findUnique({
             where: typeof idOrName === 'number' ? {
@@ -34,6 +35,7 @@ export type ImageCollectionPageReturn = ImageCollection & {
 export async function readImageCollectionsPage<const PageSize extends number>(
     { page }: ReadPageInput<PageSize>
 ): Promise<ActionReturn<ImageCollectionPageReturn[]>> {
+    //TODO: Auth image collections on visibility or permission (if special collection)
     try {
         const { page: pageNumber, pageSize } = page
         const collections = await prisma.imageCollection.findMany({
@@ -85,6 +87,7 @@ export async function readImageCollectionsPage<const PageSize extends number>(
  * @returns the special collection
  */
 export async function readSpecialImageCollection(special: SpecialCollection): Promise<ActionReturn<ImageCollection>> {
+    //TODO: Auth special image collections on permission (not visibility)
     try {
         const collection = await prisma.imageCollection.findUnique({
             where: {

--- a/src/actions/news/create.ts
+++ b/src/actions/news/create.ts
@@ -8,7 +8,6 @@ import errorHandler from '@/prisma/errorHandler'
 import type { ActionReturn } from '@/actions/Types'
 import type { ExpandedNewsArticle } from './Types'
 import type { NewsArticleSchemaType } from './schema'
-import { ombulSchema } from '../ombul/schema'
 
 export async function createNews(rawdata: FormData | NewsArticleSchemaType): Promise<ActionReturn<ExpandedNewsArticle>> {
     //TODO: check for can create news permission

--- a/src/actions/news/create.ts
+++ b/src/actions/news/create.ts
@@ -8,6 +8,7 @@ import errorHandler from '@/prisma/errorHandler'
 import type { ActionReturn } from '@/actions/Types'
 import type { ExpandedNewsArticle } from './Types'
 import type { NewsArticleSchemaType } from './schema'
+import { ombulSchema } from '../ombul/schema'
 
 export async function createNews(rawdata: FormData | NewsArticleSchemaType): Promise<ActionReturn<ExpandedNewsArticle>> {
     //TODO: check for can create news permission
@@ -22,7 +23,7 @@ export async function createNews(rawdata: FormData | NewsArticleSchemaType): Pro
 
     const res = await readCurrenOmegaOrder()
     if (!res.success) return res
-    const orderPublished = res.data.order
+    const currentOrder = res.data
 
     try {
         const article = await createArticle(data.name)
@@ -38,7 +39,9 @@ export async function createNews(rawdata: FormData | NewsArticleSchemaType): Pro
                     }
                 },
                 endDateTime: data.endDateTime || endDateTime,
-                orderPublished,
+                omegaOrder: {
+                    connect: currentOrder
+                }
             },
             include: {
                 article: {

--- a/src/prisma/prismaservice/src/development/seedDevNews.ts
+++ b/src/prisma/prismaservice/src/development/seedDevNews.ts
@@ -1,6 +1,9 @@
 import type { PrismaClient } from '@prisma/client'
 
 export default async function seedDevNews(prisma: PrismaClient) {
+    const order = await prisma.omegaOrder.findFirst()
+    if (!order) throw new Error('No omega order found to seed news to')
+
     // seed old news
     const date = new Date()
     date.setDate(date.getDate() - 365) // Subtract 365 days from the current date
@@ -25,7 +28,9 @@ export default async function seedDevNews(prisma: PrismaClient) {
                     }
                 },
                 endDateTime: date,
-                orderPublished: i,
+                omegaOrder: {
+                    connect: order,
+                },
             }
         })
     }
@@ -49,7 +54,9 @@ export default async function seedDevNews(prisma: PrismaClient) {
                     }
                 },
                 endDateTime: new Date(),
-                orderPublished: i,
+                omegaOrder: {
+                    connect: order,
+                }
             }
         })
     }

--- a/src/prisma/prismaservice/src/dobbelOmega/migateArticles.ts
+++ b/src/prisma/prismaservice/src/dobbelOmega/migateArticles.ts
@@ -90,6 +90,17 @@ export default async function migrateArticles(
         if (new Date(article.createdAt).getMonth() < 8) {
             orderPublished--
         }
+        await pnPrisma.omegaOrder.upsert({
+            where: {
+                order: orderPublished,
+            },
+            update: {
+                order: orderPublished,
+            },
+            create: {
+                order: orderPublished,
+            }
+        })
 
         return {
             ...articlePn,
@@ -136,7 +147,11 @@ export default async function migrateArticles(
                         id: articlePn.id,
                     }
                 },
-                orderPublished: articlePn.orderPublished,
+                omegaOrder: {
+                    connect: {
+                        order: articlePn.orderPublished,
+                    }
+                },
                 endDateTime: articlePn.endDateTime,
             }
         })

--- a/src/prisma/prismaservice/src/dobbelOmega/migrationLimits.ts
+++ b/src/prisma/prismaservice/src/dobbelOmega/migrationLimits.ts
@@ -1,5 +1,5 @@
 /**
- * Returns Limits for the migration process to test without going crazy
+ * @returns Limits for the migration process to test without going crazy
  * null means no limit and happens if the env variable MIGRATION_WITH_LIMITS is set to "false"
  */
 export function getLimits() {

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -240,13 +240,13 @@ model Article {
 }
 
 model NewsArticle {
-  id             Int         @id @default(autoincrement())
+  id             Int        @id @default(autoincrement())
   description    String?
   endDateTime    DateTime //when the article is no longer considered current
-  article        Article     @relation(fields: [articleId, articleName], references: [id, name], onDelete: Cascade) //This should always be set, but it is not required by schema (prisma limitation)
-  articleId      Int         @unique
+  article        Article    @relation(fields: [articleId, articleName], references: [id, name], onDelete: Cascade) //This should always be set, but it is not required by schema (prisma limitation)
+  articleId      Int        @unique
   articleName    String
-  omegaOrder     OmegaOrder? @relation(fields: [orderPublished], references: [order])
+  omegaOrder     OmegaOrder @relation(fields: [orderPublished], references: [order])
   orderPublished Int
 
   @@unique([articleId, articleName])

--- a/src/prisma/schema.prisma
+++ b/src/prisma/schema.prisma
@@ -172,7 +172,6 @@ model CmsImage {
   articleSectionId     Int?            @unique
   coverImageforArticle Article?
   Ombul                Ombul?
-  
 }
 
 model CmsParagraph {
@@ -241,12 +240,13 @@ model Article {
 }
 
 model NewsArticle {
-  id             Int      @id @default(autoincrement())
+  id             Int         @id @default(autoincrement())
   description    String?
   endDateTime    DateTime //when the article is no longer considered current
-  article        Article  @relation(fields: [articleId, articleName], references: [id, name], onDelete: Cascade) //This should always be set, but it is not required by schema (prisma limitation)
-  articleId      Int      @unique
+  article        Article     @relation(fields: [articleId, articleName], references: [id, name], onDelete: Cascade) //This should always be set, but it is not required by schema (prisma limitation)
+  articleId      Int         @unique
   articleName    String
+  omegaOrder     OmegaOrder? @relation(fields: [orderPublished], references: [order])
   orderPublished Int
 
   @@unique([articleId, articleName])
@@ -296,9 +296,10 @@ model StudyProgram {
 ///////////////////////////
 
 model OmegaOrder {
-  order     Int      @id
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  order       Int           @id
+  createdAt   DateTime      @default(now())
+  updatedAt   DateTime      @updatedAt
+  NewsArticle NewsArticle[]
 }
 
 ///////////////////////////
@@ -307,7 +308,7 @@ model OmegaOrder {
 
 model Ombul {
   id           Int      @id @default(autoincrement())
-  name         String   
+  name         String
   description  String?
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt


### PR DESCRIPTION
I think it probably makes more sense to have things that use order (only newsArticles for now) have a relation to omegaOrder  that references order rather than copying. It is a very minor change, but I think it from a sql modeling perspective makes more sense.