### PR TITLE
refactor: add satisfies keyword to config vars marked as const

### DIFF
--- a/src/prisma/prismaservice/src/seedImagesConfig.ts
+++ b/src/prisma/prismaservice/src/seedImagesConfig.ts
@@ -7,7 +7,7 @@ type ImageSeedConfigBase = {
     collection: string,
 }
 
-const defaultCollection = 'STANDARDIMAGES' as const
+const defaultCollection = 'STANDARDIMAGES' satisfies SpecialCollection
 
 type ImageSeedConfig = ImageSeedConfigBase[]
 

--- a/src/server/cms/articleSections/ConfigVars.ts
+++ b/src/server/cms/articleSections/ConfigVars.ts
@@ -1,3 +1,5 @@
+import type { Prisma } from '@prisma/client'
+
 export const maxImageSize = 540
 export const minImageSize = 130
 export const imageSizeIncrement = 20
@@ -7,8 +9,7 @@ export const articleSectionsRealtionsIncluder = {
         include: {
             image: true
         }
-
     },
     cmsParagraph: true,
-    cmsLink: true
-} as const
+    cmsLink: true,
+} as const satisfies Prisma.ArticleSectionInclude

--- a/src/server/cms/articleSections/update.ts
+++ b/src/server/cms/articleSections/update.ts
@@ -10,7 +10,7 @@ import { createCmsParagraph } from '@/server/cms/paragraphs/create'
 import { createCmsLink } from '@/server/cms/links/create'
 import { prismaCall } from '@/server/prismaCall'
 import { ServerError } from '@/server/error'
-import type { ImageSize, ArticleSection, Position } from '@prisma/client'
+import type { ImageSize, ArticleSection, Position, Prisma } from '@prisma/client'
 import type { ExpandedArticleSection, ArticleSectionPart } from '@/cms/articleSections/Types'
 
 /**
@@ -75,7 +75,7 @@ export async function addArticleSectionPart(
     const where = {
         name: typeof nameOrId === 'string' ? nameOrId : undefined,
         id: typeof nameOrId === 'number' ? nameOrId : undefined
-    } as const
+    } as const satisfies Prisma.ArticleSectionWhereUniqueInput
 
     const articleSection = await prismaCall(() => prisma.articleSection.findUnique({
         where,
@@ -137,7 +137,7 @@ export async function removeArticleSectionPart(
     const where = {
         name: typeof nameOrId === 'string' ? nameOrId : undefined,
         id: typeof nameOrId === 'number' ? nameOrId : undefined
-    } as const
+    } as const satisfies Prisma.ArticleSectionWhereUniqueInput
     const articleSection = await prismaCall(() => prisma.articleSection.findUnique({
         where,
         include: { cmsLink: true, cmsParagraph: true, cmsImage: true }

--- a/src/server/cms/articles/ConfigVars.ts
+++ b/src/server/cms/articles/ConfigVars.ts
@@ -1,9 +1,9 @@
 import { articleSectionsRealtionsIncluder } from '@/cms/articleSections/ConfigVars'
-import { Prisma } from '@prisma/client'
+import type { Prisma } from '@prisma/client'
 
 export const maxSections = 10 // Max 10 sections in an article
 
-export const articleRealtionsIncluder = Prisma.validator<Prisma.ArticleInclude>()({
+export const articleRealtionsIncluder = {
     articleSections: {
         include: articleSectionsRealtionsIncluder
     },
@@ -12,4 +12,4 @@ export const articleRealtionsIncluder = Prisma.validator<Prisma.ArticleInclude>(
             image: true
         },
     },
-})
+} as const satisfies Prisma.ArticleInclude

--- a/src/server/cms/articles/update.ts
+++ b/src/server/cms/articles/update.ts
@@ -87,7 +87,7 @@ export async function addSectionToArticle(
         include: articleRealtionsIncluder,
     }))
 
-    for (const part of ['cmsParagraph', 'cmsLink', 'cmsImage'] as const) {
+    for (const part of ['cmsParagraph', 'cmsLink', 'cmsImage'] satisfies ArticleSectionPart[]) {
         if (include[part]) {
             await addArticleSectionPart(newSectionName, part)
         }

--- a/src/server/news/ConfigVars.ts
+++ b/src/server/news/ConfigVars.ts
@@ -1,4 +1,5 @@
 import { articleRealtionsIncluder } from '@/cms/articles/ConfigVars'
+import type { Prisma } from '@prisma/client'
 
 export const defaultNewsArticleOldCutoff = 7 // by default a newsarticle is considered old after 7 days
 
@@ -6,7 +7,7 @@ export const newsArticleRealtionsIncluder = {
     article: {
         include: articleRealtionsIncluder
     }
-} as const
+} as const satisfies Prisma.NewsArticleInclude
 
 export const simpleNewsArticleRealtionsIncluder = {
     article: {
@@ -18,4 +19,4 @@ export const simpleNewsArticleRealtionsIncluder = {
             }
         }
     }
-} as const
+} as const satisfies Prisma.NewsArticleInclude

--- a/src/server/omegaquotes/CofigVars.ts
+++ b/src/server/omegaquotes/CofigVars.ts
@@ -1,4 +1,5 @@
 import { createSelection } from '@/server/createSelection'
+import type { OmegaQuote } from '@prisma/client'
 
-export const omegaQuoteFieldsToExpose = ['id', 'author', 'quote', 'timestamp'] as const
+export const omegaQuoteFieldsToExpose = ['id', 'author', 'quote', 'timestamp'] as const satisfies (keyof OmegaQuote)[]
 export const omegaQuoteFilterSelection = createSelection([...omegaQuoteFieldsToExpose])

--- a/src/server/permissionRoles/ConfigVars.ts
+++ b/src/server/permissionRoles/ConfigVars.ts
@@ -1,6 +1,6 @@
-import { Prisma } from '@prisma/client'
+import type { Prisma } from '@prisma/client'
 
-export const expandedRoleIncluder = Prisma.validator<Prisma.RoleInclude>()({
+export const expandedRoleIncluder = {
     permissions: {
         select: {
             permission: true,
@@ -12,4 +12,4 @@ export const expandedRoleIncluder = Prisma.validator<Prisma.RoleInclude>()({
             forAdminsOnly: true,
         },
     },
-})
+} as const satisfies Prisma.RoleInclude

--- a/src/server/users/ConfigVars.ts
+++ b/src/server/users/ConfigVars.ts
@@ -1,4 +1,13 @@
 import { createSelection } from '@/server/createSelection'
+import type { User } from '@prisma/client'
 
-export const userFieldsToExpose = ['id', 'username', 'firstname', 'lastname', 'email', 'createdAt', 'updatedAt'] as const
+export const userFieldsToExpose = [
+    'id',
+    'username',
+    'firstname',
+    'lastname',
+    'email',
+    'createdAt',
+    'updatedAt',
+] as const satisfies (keyof User)[]
 export const userFilterSelection = createSelection([...userFieldsToExpose])


### PR DESCRIPTION
Found out that typescript has this neat little keyword `satisfies`. All it does is that it forces the left side of it to satisfy the type of the right side. Why is this useful? Well it works a bit like `as const`, as in it makes typescript narrow down the type of the value as much as possible, but with the benifit of having the ability to specify a type. For example, previously we had this array for which user fields to expose:

```ts
export const userFieldsToExpose = ['id', 'username', 'firstname', 'lastname', 'email', 'createdAt', 'updatedAt'] as const
```

The problem here is that if you misspell any of the fields you won't get an error here. You'll most likely catch the error if you try to use the array, but it would be nice to have an error straight away. In addition, you don't get intellisense autocomplete when you write in which fields you want to expose. The satisfies keywors solves this issue:

```ts
export const userFieldsToExpose = ['id', 'username', 'firstname', 'lastname', 'email', 'createdAt', 'updatedAt'] as const satisfies (keyof User)[]
```

Now we have explicitly marked that this array satisfies the type (keyof User)[]. Now typescript will check that the left side is an array of keys of the object type User. This also allowes intellisense to give hints for which fields you want to type. 

The satisfies keyword especially becomes usefull for prisma input types. Now you can have autocomplete on you includers by doing something like this:

```ts
export const articleRealtionsIncluder = {
    articleSections: {
        include: articleSectionsRealtionsIncluder
    },
    coverImage: {
        include: {
            image: true
        },
    },
} as const satisfies Prisma.ArticleInclude
```

I have gone through the project and added the satisfies keyword with the proper type wherever I have seen an `as const.` I think this is something we should be doing from now on.