### PR TITLE
Chore/npm audit october 2024

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
     - name: set up node
       uses: actions/setup-node@v3
       with:
-        node-version: '20.x'
+        node-version: '22.x'
 
     - name: Install dependencies 
       run: npm ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS base
+FROM node:22-alpine AS base
 WORKDIR /usr/src/app
 
 # Install node packages
@@ -16,7 +16,7 @@ COPY public public
 COPY next-env.d.t[s] next.config.js tsconfig.json ./
 
 ############################################################
-FROM node:20-alpine AS prod
+FROM node:22-alpine AS prod
 WORKDIR /usr/src/app
 
 COPY src src
@@ -25,7 +25,7 @@ COPY --from=base /usr/src/app/ .
 RUN npm run build
 CMD ["npm", "run", "start"]
 ############################################################
-FROM node:20-alpine AS dev
+FROM node:22-alpine AS dev
 WORKDIR /usr/src/app
 
 COPY --from=base /usr/src/app/ .

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "react-dom": "^18.3.1",
         "react-fontawesome": "^1.7.1",
         "react-intersection-observer": "^9.13.0",
-        "react-pdf": "^7.7.1",
+        "react-pdf": "^9.1.1",
         "react-simplemde-editor": "^5.2.0",
         "rehype-format": "^5.0.0",
         "rehype-stringify": "^10.0.0",
@@ -690,9 +690,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "14.2.5",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.5.tgz",
-      "integrity": "sha512-/zZGkrTOsraVfYjGP8uM0p6r0BDT6xWpkjdVbcz66PJVSpwXX3yNiRycxAuDfBKGWBrZBXRuK/YVlkNgxHGwmA=="
+      "version": "14.2.14",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.14.tgz",
+      "integrity": "sha512-/0hWQfiaD5//LvGNgc8PjvyqV50vGK0cADYzaoOOGN8fxzBn3iAiaq3S0tCRnFBldq0LVveLcxCTi41ZoYgAgg=="
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "14.2.5",
@@ -746,9 +746,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "14.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.5.tgz",
-      "integrity": "sha512-/9zVxJ+K9lrzSGli1///ujyRfon/ZneeZ+v4ptpiPoOU+GKZnm8Wj8ELWU1Pm7GHltYRBklmXMTUqM/DqQ99FQ==",
+      "version": "14.2.14",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.14.tgz",
+      "integrity": "sha512-bsxbSAUodM1cjYeA4o6y7sp9wslvwjSkWw57t8DtC8Zig8aG8V6r+Yc05/9mDzLKcybb6EN85k1rJDnMKBd9Gw==",
       "cpu": [
         "arm64"
       ],
@@ -761,9 +761,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "14.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.5.tgz",
-      "integrity": "sha512-vXHOPCwfDe9qLDuq7U1OYM2wUY+KQ4Ex6ozwsKxp26BlJ6XXbHleOUldenM67JRyBfVjv371oneEvYd3H2gNSA==",
+      "version": "14.2.14",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.14.tgz",
+      "integrity": "sha512-cC9/I+0+SK5L1k9J8CInahduTVWGMXhQoXFeNvF0uNs3Bt1Ub0Azb8JzTU9vNCr0hnaMqiWu/Z0S1hfKc3+dww==",
       "cpu": [
         "x64"
       ],
@@ -776,9 +776,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.5.tgz",
-      "integrity": "sha512-vlhB8wI+lj8q1ExFW8lbWutA4M2ZazQNvMWuEDqZcuJJc78iUnLdPPunBPX8rC4IgT6lIx/adB+Cwrl99MzNaA==",
+      "version": "14.2.14",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.14.tgz",
+      "integrity": "sha512-RMLOdA2NU4O7w1PQ3Z9ft3PxD6Htl4uB2TJpocm+4jcllHySPkFaUIFacQ3Jekcg6w+LBaFvjSPthZHiPmiAUg==",
       "cpu": [
         "arm64"
       ],
@@ -791,9 +791,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.5.tgz",
-      "integrity": "sha512-NpDB9NUR2t0hXzJJwQSGu1IAOYybsfeB+LxpGsXrRIb7QOrYmidJz3shzY8cM6+rO4Aojuef0N/PEaX18pi9OA==",
+      "version": "14.2.14",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.14.tgz",
+      "integrity": "sha512-WgLOA4hT9EIP7jhlkPnvz49iSOMdZgDJVvbpb8WWzJv5wBD07M2wdJXLkDYIpZmCFfo/wPqFsFR4JS4V9KkQ2A==",
       "cpu": [
         "arm64"
       ],
@@ -806,9 +806,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.5.tgz",
-      "integrity": "sha512-8XFikMSxWleYNryWIjiCX+gU201YS+erTUidKdyOVYi5qUQo/gRxv/3N1oZFCgqpesN6FPeqGM72Zve+nReVXQ==",
+      "version": "14.2.14",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.14.tgz",
+      "integrity": "sha512-lbn7svjUps1kmCettV/R9oAvEW+eUI0lo0LJNFOXoQM5NGNxloAyFRNByYeZKL3+1bF5YE0h0irIJfzXBq9Y6w==",
       "cpu": [
         "x64"
       ],
@@ -821,9 +821,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.5.tgz",
-      "integrity": "sha512-6QLwi7RaYiQDcRDSU/os40r5o06b5ue7Jsk5JgdRBGGp8l37RZEh9JsLSM8QF0YDsgcosSeHjglgqi25+m04IQ==",
+      "version": "14.2.14",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.14.tgz",
+      "integrity": "sha512-7TcQCvLQ/hKfQRgjxMN4TZ2BRB0P7HwrGAYL+p+m3u3XcKTraUFerVbV3jkNZNwDeQDa8zdxkKkw2els/S5onQ==",
       "cpu": [
         "x64"
       ],
@@ -836,9 +836,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.5.tgz",
-      "integrity": "sha512-1GpG2VhbspO+aYoMOQPQiqc/tG3LzmsdBH0LhnDS3JrtDx2QmzXe0B6mSZZiN3Bq7IOMXxv1nlsjzoS1+9mzZw==",
+      "version": "14.2.14",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.14.tgz",
+      "integrity": "sha512-8i0Ou5XjTLEje0oj0JiI0Xo9L/93ghFtAUYZ24jARSeTMXLUx8yFIdhS55mTExq5Tj4/dC2fJuaT4e3ySvXU1A==",
       "cpu": [
         "arm64"
       ],
@@ -851,9 +851,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.5.tgz",
-      "integrity": "sha512-Igh9ZlxwvCDsu6438FXlQTHlRno4gFpJzqPjSIBZooD22tKeI4fE/YMRoHVJHmrQ2P5YL1DoZ0qaOKkbeFWeMg==",
+      "version": "14.2.14",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.14.tgz",
+      "integrity": "sha512-2u2XcSaDEOj+96eXpyjHjtVPLhkAFw2nlaz83EPeuK4obF+HmtDJHqgR1dZB7Gb6V/d55FL26/lYVd0TwMgcOQ==",
       "cpu": [
         "ia32"
       ],
@@ -866,9 +866,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.5.tgz",
-      "integrity": "sha512-tEQ7oinq1/CjSG9uSTerca3v4AZ+dFa+4Yu6ihaG8Ud8ddqLQgFGcnwYls13H5X5CPDPZJdYxyeMui6muOLd4g==",
+      "version": "14.2.14",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.14.tgz",
+      "integrity": "sha512-MZom+OvZ1NZxuRovKt1ApevjiUJTcU2PmdJKL66xUPaJeRywnbGGRWUlaAOwunD6dX+pm83vj979NTC8QXjGWg==",
       "cpu": [
         "x64"
       ],
@@ -4961,14 +4961,14 @@
       }
     },
     "node_modules/merge-refs": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/merge-refs/-/merge-refs-1.2.2.tgz",
-      "integrity": "sha512-RwcT7GsQR3KbuLw1rRuodq4Nt547BKEBkliZ0qqsrpyNne9bGTFtsFIsIpx82huWhcl3kOlOlH4H0xkPk/DqVw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/merge-refs/-/merge-refs-1.3.0.tgz",
+      "integrity": "sha512-nqXPXbso+1dcKDpPCXvwZyJILz+vSLqGGOnDrYHQYE+B8n9JTCekVLC65AfCpR4ggVyA/45Y0iR9LDyS2iI+zA==",
       "funding": {
         "url": "https://github.com/wojtekmaj/merge-refs?sponsor=1"
       },
       "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -5406,11 +5406,11 @@
       ]
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -5504,9 +5504,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/nan": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.18.0.tgz",
-      "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==",
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.20.0.tgz",
+      "integrity": "sha512-bk3gXBZDGILuuo/6sKtr0DQmSThYHLtNCdSdXk9YkxD/jK6X2vmCyyXBBxyqZ4XcnzTyYEAThfX3DCEnLf6igw==",
       "optional": true
     },
     "node_modules/nanoid": {
@@ -5532,11 +5532,11 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="
     },
     "node_modules/next": {
-      "version": "14.2.5",
-      "resolved": "https://registry.npmjs.org/next/-/next-14.2.5.tgz",
-      "integrity": "sha512-0f8aRfBVL+mpzfBjYfQuLWh2WyAwtJXCRfkPF4UJ5qd2YwrHczsrSzXU4tRMV0OAxR8ZJZWPFn6uhSC56UTsLA==",
+      "version": "14.2.14",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.14.tgz",
+      "integrity": "sha512-Q1coZG17MW0Ly5x76shJ4dkC23woLAhhnDnw+DfTc7EpZSGuWrlsZ3bZaO8t6u1Yu8FVfhkqJE+U8GC7E0GLPQ==",
       "dependencies": {
-        "@next/env": "14.2.5",
+        "@next/env": "14.2.14",
         "@swc/helpers": "0.5.5",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001579",
@@ -5551,15 +5551,15 @@
         "node": ">=18.17.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "14.2.5",
-        "@next/swc-darwin-x64": "14.2.5",
-        "@next/swc-linux-arm64-gnu": "14.2.5",
-        "@next/swc-linux-arm64-musl": "14.2.5",
-        "@next/swc-linux-x64-gnu": "14.2.5",
-        "@next/swc-linux-x64-musl": "14.2.5",
-        "@next/swc-win32-arm64-msvc": "14.2.5",
-        "@next/swc-win32-ia32-msvc": "14.2.5",
-        "@next/swc-win32-x64-msvc": "14.2.5"
+        "@next/swc-darwin-arm64": "14.2.14",
+        "@next/swc-darwin-x64": "14.2.14",
+        "@next/swc-linux-arm64-gnu": "14.2.14",
+        "@next/swc-linux-arm64-musl": "14.2.14",
+        "@next/swc-linux-x64-gnu": "14.2.14",
+        "@next/swc-linux-x64-musl": "14.2.14",
+        "@next/swc-win32-arm64-msvc": "14.2.14",
+        "@next/swc-win32-ia32-msvc": "14.2.14",
+        "@next/swc-win32-x64-msvc": "14.2.14"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -5581,9 +5581,9 @@
       }
     },
     "node_modules/next-auth": {
-      "version": "4.24.7",
-      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.7.tgz",
-      "integrity": "sha512-iChjE8ov/1K/z98gdKbn2Jw+2vLgJtVV39X+rCP5SGnVQuco7QOr19FRNGMIrD8d3LYhHWV9j9sKLzq1aDWWQQ==",
+      "version": "4.24.8",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.8.tgz",
+      "integrity": "sha512-SLt3+8UCtklsotnz2p+nB4aN3IHNmpsQFAZ24VLxGotWGzSxkBh192zxNhm/J5wgkcrDWVp0bwqvW0HksK/Lcw==",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
         "@panva/hkdf": "^1.0.2",
@@ -5596,12 +5596,16 @@
         "uuid": "^8.3.2"
       },
       "peerDependencies": {
+        "@auth/core": "0.34.2",
         "next": "^12.2.5 || ^13 || ^14",
         "nodemailer": "^6.6.5",
         "react": "^17.0.2 || ^18",
         "react-dom": "^17.0.2 || ^18"
       },
       "peerDependenciesMeta": {
+        "@auth/core": {
+          "optional": true
+        },
         "nodemailer": {
           "optional": true
         }
@@ -6003,25 +6007,25 @@
         "node": ">=8"
       }
     },
-    "node_modules/path2d-polyfill": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/path2d-polyfill/-/path2d-polyfill-2.0.1.tgz",
-      "integrity": "sha512-ad/3bsalbbWhmBo0D6FZ4RNMwsLsPpL6gnvhuSaU5Vm7b06Kr5ubSltQQ0T7YKsiJQO+g22zJ4dJKNTXIyOXtA==",
+    "node_modules/path2d": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/path2d/-/path2d-0.2.1.tgz",
+      "integrity": "sha512-Fl2z/BHvkTNvkuBzYTpTuirHZg6wW9z8+4SND/3mDTEcYbbNKWAy21dz9D3ePNNwrrK8pqZO5vLPZ1hLF6T7XA==",
       "optional": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=6"
       }
     },
     "node_modules/pdfjs-dist": {
-      "version": "3.11.174",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-3.11.174.tgz",
-      "integrity": "sha512-TdTZPf1trZ8/UFu5Cx/GXB7GZM30LT+wWUNfsi6Bq8ePLnb+woNKtDymI2mxZYBpMbonNFqKmiz684DIfnd8dA==",
+      "version": "4.4.168",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-4.4.168.tgz",
+      "integrity": "sha512-MbkAjpwka/dMHaCfQ75RY1FXX3IewBVu6NGZOcxerRFlaBiIkZmUoR0jotX5VUzYZEXAGzSFtknWs5xRKliXPA==",
       "engines": {
         "node": ">=18"
       },
       "optionalDependencies": {
         "canvas": "^2.11.2",
-        "path2d-polyfill": "^2.0.1"
+        "path2d": "^0.2.0"
       }
     },
     "node_modules/peberminta": {
@@ -6264,17 +6268,16 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-pdf": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/react-pdf/-/react-pdf-7.7.3.tgz",
-      "integrity": "sha512-a2VfDl8hiGjugpqezBTUzJHYLNB7IS7a2t7GD52xMI9xHg8LdVaTMsnM9ZlNmKadnStT/tvX5IfV0yLn+JvYmw==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/react-pdf/-/react-pdf-9.1.1.tgz",
+      "integrity": "sha512-Cn3RTJZMqVOOCgLMRXDamLk4LPGfyB2Np3OwQAUjmHIh47EpuGW1OpAA1Z1GVDLoHx4d5duEDo/YbUkDbr4QFQ==",
       "dependencies": {
         "clsx": "^2.0.0",
         "dequal": "^2.0.3",
         "make-cancellable-promise": "^1.3.1",
         "make-event-props": "^1.6.0",
-        "merge-refs": "^1.2.1",
-        "pdfjs-dist": "3.11.174",
-        "prop-types": "^15.6.2",
+        "merge-refs": "^1.3.0",
+        "pdfjs-dist": "4.4.168",
         "tiny-invariant": "^1.0.0",
         "warning": "^4.0.0"
       },
@@ -6282,9 +6285,9 @@
         "url": "https://github.com/wojtekmaj/react-pdf?sponsor=1"
       },
       "peerDependencies": {
-        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2061,9 +2061,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001579",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001579.tgz",
-      "integrity": "sha512-u5AUVkixruKHJjw/pj9wISlcMpgFWzSrczLZbrqBSxukQixmg0SJ5sZTpvaFvxU0HoQKd4yoyAogyrAz9pzJnA==",
+      "version": "1.0.30001667",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001667.tgz",
+      "integrity": "sha512-7LTwJjcRkzKFmtqGsibMeuXmvFDfZq/nzIjnmgCGzKKRVzjD72selLDK1oPF/Oxzmt4fNcPvTDvGqSDG4tCALw==",
       "funding": [
         {
           "type": "opencollective",
@@ -2077,7 +2077,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/canvas": {
       "version": "2.11.2",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "react-dom": "^18.3.1",
     "react-fontawesome": "^1.7.1",
     "react-intersection-observer": "^9.13.0",
-    "react-pdf": "^7.7.1",
+    "react-pdf": "^9.1.1",
     "react-simplemde-editor": "^5.2.0",
     "rehype-format": "^5.0.0",
     "rehype-stringify": "^10.0.0",

--- a/src/app/_components/PdfDocument/PdfDocument.module.scss
+++ b/src/app/_components/PdfDocument/PdfDocument.module.scss
@@ -41,3 +41,12 @@
         }
     }
 }
+
+.fallbackWarning {
+    color: ohma.$colors-red;
+}
+
+.fallback {
+    width: 70%;
+    height: 90vh;
+}

--- a/src/app/_components/PdfDocument/PdfDocument.tsx
+++ b/src/app/_components/PdfDocument/PdfDocument.tsx
@@ -12,7 +12,10 @@ import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons
 import 'react-pdf/dist/esm/Page/AnnotationLayer.css'
 import 'react-pdf/dist/esm/Page/TextLayer.css'
 
-pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.js`
+pdfjs.GlobalWorkerOptions.workerSrc = new URL(
+    'pdfjs-dist/build/pdf.worker.min.mjs',
+    import.meta.url,
+  ).toString();
 
 type PropTypes = {
     src: string

--- a/src/app/_components/PdfDocument/PdfDocument.tsx
+++ b/src/app/_components/PdfDocument/PdfDocument.tsx
@@ -12,10 +12,7 @@ import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons
 import 'react-pdf/dist/esm/Page/AnnotationLayer.css'
 import 'react-pdf/dist/esm/Page/TextLayer.css'
 
-pdfjs.GlobalWorkerOptions.workerSrc = new URL(
-    'pdfjs-dist/build/pdf.worker.min.mjs',
-    import.meta.url,
-  ).toString();
+pdfjs.GlobalWorkerOptions.workerSrc = `//unpkg.com/pdfjs-dist@${pdfjs.version}/build/pdf.worker.min.mjs`
 
 type PropTypes = {
     src: string
@@ -95,6 +92,17 @@ export default function PdfDocument({ src, className }: PropTypes) {
         if (leftPage) return `Side ${leftPage} av ${numPages}`
         if (rightPage) return `Side ${rightPage} av ${numPages}`
         return ''
+    }
+
+    if (typeof window !== 'undefined' && !window.Promise.withResolvers) {
+        return (
+            <>
+            <p className={styles.fallbackWarning}>
+                Din nettleser støtter ikke vevens fantastiske PDF-løsning. Bruker alternativ løsning.
+            </p>
+            <embed className={styles.fallback} src={src} type="application/pdf" />
+            </>
+        )
     }
 
     return (

--- a/src/app/_components/PopUp/PopUp.module.scss
+++ b/src/app/_components/PopUp/PopUp.module.scss
@@ -22,6 +22,7 @@
 }
 
 .closeBtn {
+    background-color: ohma.$colors-red;
     @include ohma.roundBtn(ohma.$colors-red);
 }
 

--- a/src/app/ombul/CreateOmbul.module.scss
+++ b/src/app/ombul/CreateOmbul.module.scss
@@ -1,20 +1,21 @@
 @use '@/styles/ohma';
 
 .CreateOmbul {
+    min-width: 60vw;
     display: grid;
     grid-template-columns: 1fr 1fr;
     @include ohma.screenMobile {
         grid-template-columns: 1fr;
     }
     grid-template-rows: auto auto;
-    gap: ohma.$gap;
+    gap: 5*ohma.$gap;
     h1 {
         grid-column: 1 / 3;
         grid-row: 1 / 2;
     }
     .form {
         grid-column: 1 / 2;
-        min-width: 35vw;
+        min-width: 30vw;
         textarea {
             min-height: 100px;
         }
@@ -22,12 +23,12 @@
     .imgPreview {
         grid-column: 2 / 3;
         margin-left: 2*ohma.$gap;
-        width: 100%;
-        height: 100%;
+        width: 70%;
+        height: 70%;
         min-width: 20vw;
         max-width: 30vw;
         img {
-            width: 100% !important;
+            width: 70% !important;
             height: 100%;
             object-fit: contain;
             margin-bottom: ohma.$gap;

--- a/src/auth/VevenAdapter.ts
+++ b/src/auth/VevenAdapter.ts
@@ -6,7 +6,7 @@ import { User } from '@/services/users'
 import { readUserOrNull } from '@/services/users/read'
 import type { UserFiltered } from '@/services/users/Types'
 import type { PrismaClient } from '@prisma/client'
-import type { Adapter, AdapterUser } from 'next-auth/adapters'
+import type { Adapter, AdapterUser, AdapterAccount } from 'next-auth/adapters'
 
 /**
  * Utility function for converting a user object to
@@ -78,7 +78,7 @@ async function generateUsername(prisma: PrismaClient, preferredUsername: string,
 
 export default function VevenAdapter(prisma: PrismaClient): Adapter {
     return {
-        async createUser(user) {
+        async createUser(user: AdapterUser) {
             if (!user.username || !user.firstname || !user.lastname) {
                 throw new Error()
             }
@@ -146,7 +146,7 @@ export default function VevenAdapter(prisma: PrismaClient): Adapter {
             return convertToAdapterUser(updatedUser)
         },
 
-        async linkAccount(account) {
+        async linkAccount(account: AdapterAccount) {
             console.log('link acc')
 
             if (!account.access_token || !account.expires_at || !account.id_token) {

--- a/src/prisma/prismaservice/Dockerfile
+++ b/src/prisma/prismaservice/Dockerfile
@@ -1,5 +1,5 @@
 #This container is responisble for running migrations and seeding the database.
-FROM node:20-alpine AS base
+FROM node:22-alpine AS base
 
 WORKDIR /usr/src/app
 COPY ./schema ./schema
@@ -28,7 +28,7 @@ COPY /prismaservice/src ./src
 RUN npm run build
 
 ########################################################
-FROM node:20-alpine AS prod
+FROM node:22-alpine AS prod
 WORKDIR /usr/src/app
 COPY --from=base /usr/src/app .
 WORKDIR /usr/src/app/prismaservice
@@ -37,7 +37,7 @@ WORKDIR /usr/src/app/prismaservice
 CMD ["/bin/sh", "-c", "npx prisma db push --force-reset --skip-generate; npm run seed"]
 
 ########################################################
-FROM node:20-alpine AS dev
+FROM node:22-alpine AS dev
 WORKDIR /usr/src/app
 COPY --from=base /usr/src/app .
 WORKDIR /usr/src/app/prismaservice

--- a/src/prisma/schema/event.prisma
+++ b/src/prisma/schema/event.prisma
@@ -18,11 +18,11 @@ model Event {
   eventEnd     DateTime
   canBeViewdBy EventCanView
 
-  takesRegistration  Boolean
-  places             Int                 @default(0)
+  takesRegistration Boolean
+  places            Int                 @default(0)
   registrationStart DateTime
   registrationEnd   DateTime
-  EventRegistration  EventRegistration[]
+  EventRegistration EventRegistration[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt

--- a/src/prisma/schema/user.prisma
+++ b/src/prisma/schema/user.prisma
@@ -5,26 +5,26 @@ enum SEX {
 }
 
 model User {
-  id            Int           @id @default(autoincrement())
-  username      String        @unique
-  email         String        @unique
-  firstname     String        @default("[Fjernet]")
-  lastname      String        @default("[Fjernet]")
-  bio           String        @default("")
-  acceptedTerms DateTime?
-  sex           SEX?
-  allergies     String?
-  mobile        String?
-  emailVerified DateTime?
-  createdAt     DateTime      @default(now())
-  updatedAt     DateTime      @updatedAt // is also updated manually
-  image         Image?        @relation(fields: [imageId], references: [id])
-  imageId       Int?
+  id                Int                 @id @default(autoincrement())
+  username          String              @unique
+  email             String              @unique
+  firstname         String              @default("[Fjernet]")
+  lastname          String              @default("[Fjernet]")
+  bio               String              @default("")
+  acceptedTerms     DateTime?
+  sex               SEX?
+  allergies         String?
+  mobile            String?
+  emailVerified     DateTime?
+  createdAt         DateTime            @default(now())
+  updatedAt         DateTime            @updatedAt // is also updated manually
+  image             Image?              @relation(fields: [imageId], references: [id])
+  imageId           Int?
   LockerReservation LockerReservation[]
-  omegaQuote    OmegaQuote[]
-  memberships   Membership[]
-  credentials   Credentials?
-  feideAccount  FeideAccount?
+  omegaQuote        OmegaQuote[]
+  memberships       Membership[]
+  credentials       Credentials?
+  feideAccount      FeideAccount?
 
   notificationSubscriptions NotificationSubscription[]
   mailingLists              MailingListUser[]


### PR DESCRIPTION
This PR
- Upgrades to node 22
- Fixes the most critical package vulnerabilities.

We have had problems changing react-pdf version because of a missing pdfs-worker. I have now found one that works. It does depend on using Promise.withResolvers - a new method. This has two consequences:
- We should upgrade to node 22 (so the method is available server-side)
- Some older browsers might have a problem - I have created a fallback.
