### PR TITLE
chore: update prisma to 6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@fortawesome/free-brands-svg-icons": "^6.6.0",
         "@fortawesome/free-solid-svg-icons": "^6.6.0",
         "@fortawesome/react-fontawesome": "^0.2.2",
-        "@prisma/client": "^5.21.1",
+        "@prisma/client": "^6.1.0",
         "@react-email/components": "^0.0.25",
         "@react-email/render": "^1.0.1",
         "bcrypt": "^5.1.1",
@@ -55,7 +55,7 @@
         "@types/uuid": "^10.0.0",
         "eslint": "^8.57.1",
         "eslint-config-next": "^14.2.15",
-        "prisma": "^5.21.1",
+        "prisma": "^6.1.0",
         "typescript": "^5.6.3"
       }
     },
@@ -1224,12 +1224,13 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "5.21.1",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.21.1.tgz",
-      "integrity": "sha512-3n+GgbAZYjaS/k0M03yQsQfR1APbr411r74foknnsGpmhNKBG49VuUkxIU6jORgvJPChoD4WC4PqoHImN1FP0w==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.1.0.tgz",
+      "integrity": "sha512-AbQYc5+EJKm1Ydfq3KxwcGiy7wIbm4/QbjCKWWoNROtvy7d6a3gmAGkKjK0iUCzh+rHV8xDhD5Cge8ke/kiy5Q==",
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">=16.13"
+        "node": ">=18.18"
       },
       "peerDependencies": {
         "prisma": "*"
@@ -1241,48 +1242,53 @@
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "5.21.1",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.21.1.tgz",
-      "integrity": "sha512-uY8SAhcnORhvgtOrNdvWS98Aq/nkQ9QDUxrWAgW8XrCZaI3j2X7zb7Xe6GQSh6xSesKffFbFlkw0c2luHQviZA==",
-      "devOptional": true
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.1.0.tgz",
+      "integrity": "sha512-0himsvcM4DGBTtvXkd2Tggv6sl2JyUYLzEGXXleFY+7Kp6rZeSS3hiTW9mwtUlXrwYbJP6pwlVNB7jYElrjWUg==",
+      "devOptional": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
-      "version": "5.21.1",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.21.1.tgz",
-      "integrity": "sha512-hGVTldUkIkTwoV8//hmnAAiAchi4oMEKD3aW5H2RrnI50tTdwza7VQbTTAyN3OIHWlK5DVg6xV7X8N/9dtOydA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.1.0.tgz",
+      "integrity": "sha512-GnYJbCiep3Vyr1P/415ReYrgJUjP79fBNc1wCo7NP6Eia0CzL2Ot9vK7Infczv3oK7JLrCcawOSAxFxNFsAERQ==",
       "devOptional": true,
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "5.21.1",
-        "@prisma/engines-version": "5.21.1-1.bf0e5e8a04cada8225617067eaa03d041e2bba36",
-        "@prisma/fetch-engine": "5.21.1",
-        "@prisma/get-platform": "5.21.1"
+        "@prisma/debug": "6.1.0",
+        "@prisma/engines-version": "6.1.0-21.11f085a2012c0f4778414c8db2651556ee0ef959",
+        "@prisma/fetch-engine": "6.1.0",
+        "@prisma/get-platform": "6.1.0"
       }
     },
     "node_modules/@prisma/engines-version": {
-      "version": "5.21.1-1.bf0e5e8a04cada8225617067eaa03d041e2bba36",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.21.1-1.bf0e5e8a04cada8225617067eaa03d041e2bba36.tgz",
-      "integrity": "sha512-qvnEflL0//lh44S/T9NcvTMxfyowNeUxTunPcDfKPjyJNrCNf2F1zQLcUv5UHAruECpX+zz21CzsC7V2xAeM7Q==",
-      "devOptional": true
+      "version": "6.1.0-21.11f085a2012c0f4778414c8db2651556ee0ef959",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.1.0-21.11f085a2012c0f4778414c8db2651556ee0ef959.tgz",
+      "integrity": "sha512-PdJqmYM2Fd8K0weOOtQThWylwjsDlTig+8Pcg47/jszMuLL9iLIaygC3cjWJLda69siRW4STlCTMSgOjZzvKPQ==",
+      "devOptional": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "5.21.1",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.21.1.tgz",
-      "integrity": "sha512-70S31vgpCGcp9J+mh/wHtLCkVezLUqe/fGWk3J3JWZIN7prdYSlr1C0niaWUyNK2VflLXYi8kMjAmSxUVq6WGQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.1.0.tgz",
+      "integrity": "sha512-asdFi7TvPlEZ8CzSZ/+Du5wZ27q6OJbRSXh+S8ISZguu+S9KtS/gP7NeXceZyb1Jv1SM1S5YfiCv+STDsG6rrg==",
       "devOptional": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "5.21.1",
-        "@prisma/engines-version": "5.21.1-1.bf0e5e8a04cada8225617067eaa03d041e2bba36",
-        "@prisma/get-platform": "5.21.1"
+        "@prisma/debug": "6.1.0",
+        "@prisma/engines-version": "6.1.0-21.11f085a2012c0f4778414c8db2651556ee0ef959",
+        "@prisma/get-platform": "6.1.0"
       }
     },
     "node_modules/@prisma/get-platform": {
-      "version": "5.21.1",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.21.1.tgz",
-      "integrity": "sha512-sRxjL3Igst3ct+e8ya/x//cDXmpLbZQ5vfps2N4tWl4VGKQAmym77C/IG/psSMsQKszc8uFC/q1dgmKFLUgXZQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.1.0.tgz",
+      "integrity": "sha512-ia8bNjboBoHkmKGGaWtqtlgQOhCi7+f85aOkPJKgNwWvYrT6l78KgojLekE8zMhVk0R9lWcifV0Pf8l3/15V0Q==",
       "devOptional": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "5.21.1"
+        "@prisma/debug": "6.1.0"
       }
     },
     "node_modules/@react-email/body": {
@@ -6635,19 +6641,20 @@
       "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew=="
     },
     "node_modules/prisma": {
-      "version": "5.21.1",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.21.1.tgz",
-      "integrity": "sha512-PB+Iqzld/uQBPaaw2UVIk84kb0ITsLajzsxzsadxxl54eaU5Gyl2/L02ysivHxK89t7YrfQJm+Ggk37uvM70oQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.1.0.tgz",
+      "integrity": "sha512-aFI3Yi+ApUxkwCJJwyQSwpyzUX7YX3ihzuHNHOyv4GJg3X5tQsmRaJEnZ+ZyfHpMtnyahhmXVfbTZ+lS8ZtfKw==",
       "devOptional": true,
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/engines": "5.21.1"
+        "@prisma/engines": "6.1.0"
       },
       "bin": {
         "prisma": "build/index.js"
       },
       "engines": {
-        "node": ">=16.13"
+        "node": ">=18.18"
       },
       "optionalDependencies": {
         "fsevents": "2.3.3"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@fortawesome/free-brands-svg-icons": "^6.6.0",
     "@fortawesome/free-solid-svg-icons": "^6.6.0",
     "@fortawesome/react-fontawesome": "^0.2.2",
-    "@prisma/client": "^5.21.1",
+    "@prisma/client": "^6.1.0",
     "@react-email/components": "^0.0.25",
     "@react-email/render": "^1.0.1",
     "bcrypt": "^5.1.1",
@@ -60,7 +60,7 @@
     "@types/uuid": "^10.0.0",
     "eslint": "^8.57.1",
     "eslint-config-next": "^14.2.15",
-    "prisma": "^5.21.1",
+    "prisma": "^6.1.0",
     "typescript": "^5.6.3"
   }
 }

--- a/src/prisma/prismaservice/package-lock.json
+++ b/src/prisma/prismaservice/package-lock.json
@@ -19,12 +19,12 @@
         "winston": "^3.15.0"
       },
       "devDependencies": {
-        "@prisma/client": "^5.22.0",
+        "@prisma/client": "^6.1.0",
         "@types/bcrypt": "^5.0.2",
         "@types/node": "^22.9.0",
         "@types/uuid": "^10.0.0",
         "bcrypt": "^5.1.1",
-        "prisma": "^5.22.0",
+        "prisma": "^6.1.0",
         "tsc-alias": "^1.8.10",
         "tscpaths": "^0.0.9",
         "typescript": "^5.6.3"
@@ -470,13 +470,14 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.22.0.tgz",
-      "integrity": "sha512-M0SVXfyHnQREBKxCgyo7sffrKttwE6R8PMq330MIUF0pTwjUhLbW84pFDlf06B27XyCR++VtjugEnIHdr07SVA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.1.0.tgz",
+      "integrity": "sha512-AbQYc5+EJKm1Ydfq3KxwcGiy7wIbm4/QbjCKWWoNROtvy7d6a3gmAGkKjK0iUCzh+rHV8xDhD5Cge8ke/kiy5Q==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">=16.13"
+        "node": ">=18.18"
       },
       "peerDependencies": {
         "prisma": "*"
@@ -488,48 +489,53 @@
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.22.0.tgz",
-      "integrity": "sha512-AUt44v3YJeggO2ZU5BkXI7M4hu9BF2zzH2iF2V5pyXT/lRTyWiElZ7It+bRH1EshoMRxHgpYg4VB6rCM+mG5jQ==",
-      "dev": true
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.1.0.tgz",
+      "integrity": "sha512-0himsvcM4DGBTtvXkd2Tggv6sl2JyUYLzEGXXleFY+7Kp6rZeSS3hiTW9mwtUlXrwYbJP6pwlVNB7jYElrjWUg==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.22.0.tgz",
-      "integrity": "sha512-UNjfslWhAt06kVL3CjkuYpHAWSO6L4kDCVPegV6itt7nD1kSJavd3vhgAEhjglLJJKEdJ7oIqDJ+yHk6qO8gPA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.1.0.tgz",
+      "integrity": "sha512-GnYJbCiep3Vyr1P/415ReYrgJUjP79fBNc1wCo7NP6Eia0CzL2Ot9vK7Infczv3oK7JLrCcawOSAxFxNFsAERQ==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "5.22.0",
-        "@prisma/engines-version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
-        "@prisma/fetch-engine": "5.22.0",
-        "@prisma/get-platform": "5.22.0"
+        "@prisma/debug": "6.1.0",
+        "@prisma/engines-version": "6.1.0-21.11f085a2012c0f4778414c8db2651556ee0ef959",
+        "@prisma/fetch-engine": "6.1.0",
+        "@prisma/get-platform": "6.1.0"
       }
     },
     "node_modules/@prisma/engines-version": {
-      "version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2.tgz",
-      "integrity": "sha512-2PTmxFR2yHW/eB3uqWtcgRcgAbG1rwG9ZriSvQw+nnb7c4uCr3RAcGMb6/zfE88SKlC1Nj2ziUvc96Z379mHgQ==",
-      "dev": true
+      "version": "6.1.0-21.11f085a2012c0f4778414c8db2651556ee0ef959",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.1.0-21.11f085a2012c0f4778414c8db2651556ee0ef959.tgz",
+      "integrity": "sha512-PdJqmYM2Fd8K0weOOtQThWylwjsDlTig+8Pcg47/jszMuLL9iLIaygC3cjWJLda69siRW4STlCTMSgOjZzvKPQ==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.22.0.tgz",
-      "integrity": "sha512-bkrD/Mc2fSvkQBV5EpoFcZ87AvOgDxbG99488a5cexp5Ccny+UM6MAe/UFkUC0wLYD9+9befNOqGiIJhhq+HbA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.1.0.tgz",
+      "integrity": "sha512-asdFi7TvPlEZ8CzSZ/+Du5wZ27q6OJbRSXh+S8ISZguu+S9KtS/gP7NeXceZyb1Jv1SM1S5YfiCv+STDsG6rrg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "5.22.0",
-        "@prisma/engines-version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
-        "@prisma/get-platform": "5.22.0"
+        "@prisma/debug": "6.1.0",
+        "@prisma/engines-version": "6.1.0-21.11f085a2012c0f4778414c8db2651556ee0ef959",
+        "@prisma/get-platform": "6.1.0"
       }
     },
     "node_modules/@prisma/get-platform": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.22.0.tgz",
-      "integrity": "sha512-pHhpQdr1UPFpt+zFfnPazhulaZYCUqeIcPpJViYoq9R+D/yw4fjE+CtnsnKzPYm0ddUbeXUzjGVGIRVgPDCk4Q==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.1.0.tgz",
+      "integrity": "sha512-ia8bNjboBoHkmKGGaWtqtlgQOhCi7+f85aOkPJKgNwWvYrT6l78KgojLekE8zMhVk0R9lWcifV0Pf8l3/15V0Q==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "5.22.0"
+        "@prisma/debug": "6.1.0"
       }
     },
     "node_modules/@types/bcrypt": {
@@ -3168,19 +3174,20 @@
       }
     },
     "node_modules/prisma": {
-      "version": "5.22.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.22.0.tgz",
-      "integrity": "sha512-vtpjW3XuYCSnMsNVBjLMNkTj6OZbudcPPTPYHqX0CJfpcdWciI1dM8uHETwmDxxiqEwCIE6WvXucWUetJgfu/A==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.1.0.tgz",
+      "integrity": "sha512-aFI3Yi+ApUxkwCJJwyQSwpyzUX7YX3ihzuHNHOyv4GJg3X5tQsmRaJEnZ+ZyfHpMtnyahhmXVfbTZ+lS8ZtfKw==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/engines": "5.22.0"
+        "@prisma/engines": "6.1.0"
       },
       "bin": {
         "prisma": "build/index.js"
       },
       "engines": {
-        "node": ">=16.13"
+        "node": ">=18.18"
       },
       "optionalDependencies": {
         "fsevents": "2.3.3"

--- a/src/prisma/prismaservice/package.json
+++ b/src/prisma/prismaservice/package.json
@@ -25,12 +25,12 @@
     "schema": "../schema"
   },
   "devDependencies": {
-    "@prisma/client": "^5.22.0",
+    "@prisma/client": "^6.1.0",
     "@types/bcrypt": "^5.0.2",
     "@types/node": "^22.9.0",
     "@types/uuid": "^10.0.0",
     "bcrypt": "^5.1.1",
-    "prisma": "^5.22.0",
+    "prisma": "^6.1.0",
     "tsc-alias": "^1.8.10",
     "tscpaths": "^0.0.9",
     "typescript": "^5.6.3"


### PR DESCRIPTION
Does what it says in the title. For some reason dependabot didn't want to create a pr for the latest version of prisma so I did it myself. This update is essential as it fixes a critical issue prisma has with the newest version of the node:22-alpine image. #374 and #372 will be able to merge after this has been merged.