### PR TITLE
fix: service method .execute has proper type

### DIFF
--- a/src/actions/action.ts
+++ b/src/actions/action.ts
@@ -13,15 +13,15 @@ export function action<Return>(
 
 export function action<Return, ParamsSchema extends z.ZodTypeAny>(
     serviceMethod: ServiceMethodType<boolean, Return, ParamsSchema, undefined>
-): (params: z.infer<ParamsSchema>) => Promise<ActionReturn<Return>>
+): (params: z.input<ParamsSchema>) => Promise<ActionReturn<Return>>
 
 export function action<Return, DataSchema extends z.ZodTypeAny | undefined>(
     serviceMethod: ServiceMethodType<boolean, Return, undefined, DataSchema>
-): (data: z.infer<NonNullable<DataSchema>> | FormData) => Promise<ActionReturn<Return>>
+): (data: z.input<NonNullable<DataSchema>> | FormData) => Promise<ActionReturn<Return>>
 
 export function action<Return, ParamsSchema extends z.ZodTypeAny, DataSchema extends z.ZodTypeAny | undefined>(
     serviceMethod: ServiceMethodType<boolean, Return, ParamsSchema, DataSchema>
-): (params: z.infer<ParamsSchema>, data: z.infer<NonNullable<DataSchema>> | FormData) => Promise<ActionReturn<Return>>
+): (params: z.input<ParamsSchema>, data: z.input<NonNullable<DataSchema>> | FormData) => Promise<ActionReturn<Return>>
 
 /**
  * Turn a service method into suitable function for an action.

--- a/src/app/api/apiHandler.ts
+++ b/src/app/api/apiHandler.ts
@@ -16,7 +16,7 @@ type APIHandler<
 } & (ParamsSchema extends undefined ? {
     params?: undefined,
 } : {
-    params: (rawparams: RawParams) => z.infer<NonNullable<ParamsSchema>>,
+    params: (rawparams: RawParams) => z.input<NonNullable<ParamsSchema>>,
 })
 
 async function apiHandlerGeneric<Return>(req: Request, handle: (session: SessionNoUser) => Promise<Return>) {

--- a/src/services/ServiceMethod.ts
+++ b/src/services/ServiceMethod.ts
@@ -31,14 +31,14 @@ export type PrismaPossibleTransaction<
 export type ServiceMethodParamsData<
     ParamsSchema extends z.ZodTypeAny | undefined,
     DataSchema extends z.ZodTypeAny | undefined,
-    SchemaType extends 'INFERED' | 'INPUT'
+    SchemaType extends 'INFERRED' | 'INPUT'
 > = (
     ParamsSchema extends undefined ? object : {
-        params: SchemaType extends 'INFERED' ? z.infer<NonNullable<ParamsSchema>> : z.input<NonNullable<ParamsSchema>>
+        params: SchemaType extends 'INFERRED' ? z.infer<NonNullable<ParamsSchema>> : z.input<NonNullable<ParamsSchema>>
     }
 ) & (
     DataSchema extends undefined ? object : {
-        data: SchemaType extends 'INFERED' ? z.infer<NonNullable<DataSchema>> : z.input<NonNullable<DataSchema>>
+        data: SchemaType extends 'INFERRED' ? z.infer<NonNullable<DataSchema>> : z.input<NonNullable<DataSchema>>
     }
 )
 
@@ -58,7 +58,7 @@ export type ServiceMethodArguments<
 > = {
     prisma: PrismaPossibleTransaction<OpensTransaction>,
     session: SessionMaybeUser,
-} & ServiceMethodParamsData<ParamsSchema, DataSchema, 'INFERED'>
+} & ServiceMethodParamsData<ParamsSchema, DataSchema, 'INFERRED'>
 
 /**
  * This is the type for the argument that are passed to the execute method of a service method.
@@ -94,7 +94,7 @@ export type ServiceMethodConfig<
     dataSchema?: DataSchema,
     opensTransaction?: OpensTransaction,
     auther: (
-        paramsData: ServiceMethodParamsData<ParamsSchema, DataSchema, 'INFERED'>
+        paramsData: ServiceMethodParamsData<ParamsSchema, DataSchema, 'INFERRED'>
     ) => // Todo: Make prettier type for returntype of dynamic fields
         | ReturnType<AutherStaticFieldsBound<DynamicFields>['dynamicFields']>
         | Promise<ReturnType<AutherStaticFieldsBound<DynamicFields>['dynamicFields']>>,

--- a/src/services/images/schemas.ts
+++ b/src/services/images/schemas.ts
@@ -25,7 +25,7 @@ export namespace ImageSchemas {
             `Du kan bare laste opp mellom 1 og ${ImageConfig.maxNumberInOneBatch} bilder av gangen`
         ),
         licenseId: z.union([
-            z.string().optional(),
+            z.string().optional().nullable(),
             z.coerce.number().optional().or(z.literal('NULL')),
         ]).transform(
             value => {


### PR DESCRIPTION
This PR fixes an issue with ServiceMethod .execute expecting wrong type when a schema transforms a value.