### PR TITLE
refactor/replace ServerOnly authorizer with defineSubOperation and internalCall

### DIFF
--- a/src/app/lockers/[id]/page.tsx
+++ b/src/app/lockers/[id]/page.tsx
@@ -32,8 +32,7 @@ export default async function Locker({ params }: PropTypes) {
         returnUrl: `/lockers/${lockerId}`
     }).session.user
 
-    const groups = await groupOperations.readGroupsOfUser({
-        bypassAuth: true,
+    const groups = await groupOperations.readGroupsOfUser.internalCall({
         params: {
             userId: user.id,
         },

--- a/src/auth/authorizer/RequireServer.ts
+++ b/src/auth/authorizer/RequireServer.ts
@@ -1,7 +1,0 @@
-import { AuthorizerFactory } from './Authorizer'
-
-export const RequireServerOnly = AuthorizerFactory<object, object, 'USER_NOT_REQUIERED_FOR_AUTHORIZED'>(
-    ({ session }) => ({ success: false, session })
-)
-
-export const ServerOnlyAuthorizer = () => RequireServerOnly.staticFields({}).dynamicFields({})

--- a/src/auth/authorizer/ServerOnly.ts
+++ b/src/auth/authorizer/ServerOnly.ts
@@ -1,8 +1,0 @@
-import { AuthorizerFactory } from './Authorizer'
-
-export const RequireServerOnly = AuthorizerFactory(
-    ({ session }) => ({ success: false, session })
-)
-
-// To pass this auto, use `bypassAuth: true`. Method with this auth is mean to only be used internally on the server
-export const ServerOnly = () => RequireServerOnly.staticFields({}).dynamicFields({})

--- a/src/auth/nextAuth/authOptions.ts
+++ b/src/auth/nextAuth/authOptions.ts
@@ -178,8 +178,7 @@ export const authOptions: AuthOptions = {
                     params: { id: userId },
                     bypassAuth: true,
                 }),
-                permissions: await permissionOperations.readPermissionsOfUser({
-                    bypassAuth: true,
+                permissions: await permissionOperations.readPermissionsOfUser.internalCall({
                     params: {
                         userId,
                     }

--- a/src/services/articleCategories/operations.ts
+++ b/src/services/articleCategories/operations.ts
@@ -38,7 +38,7 @@ export const articleCategoryOperations = {
                 }
             })
             await Promise.all(allArticles.map(article =>
-                articleOperations.destroy({ params: { articleId: article.id }, bypassAuth: true })
+                articleOperations.destroy.internalCall({ params: { articleId: article.id } })
             ))
 
             return await prisma.articleCategory.delete({
@@ -78,7 +78,7 @@ export const articleCategoryOperations = {
         opensTransaction: true,
         operation: ({ prisma, params }) => {
             prisma.$transaction(async (tx) => {
-                const article = await articleOperations.create({ data: { }, prisma: tx, bypassAuth: true })
+                const article = await articleOperations.create.internalCall({ data: { }, prisma: tx })
                 await tx.articleCategory.update({
                     where: {
                         id: params.id
@@ -116,7 +116,7 @@ export const articleCategoryOperations = {
                 )
             }
 
-            await articleOperations.destroy({ params: { articleId: params.articleId }, bypassAuth: true })
+            await articleOperations.destroy.internalCall({ params: { articleId: params.articleId } })
         }
     }),
 

--- a/src/services/career/companies/operations.ts
+++ b/src/services/career/companies/operations.ts
@@ -14,7 +14,7 @@ export const companyOperations = {
         authorizer: () => companyAuth.create.dynamicFields({}),
         operation: async ({ prisma, data }) => {
             //TODO: tranaction when createCmsImage is service operation.
-            const logo = await cmsImageOperations.create({ data: {}, bypassAuth: true })
+            const logo = await cmsImageOperations.create.internalCall({ data: {} })
             return await prisma.company.create({
                 data: {
                     ...data,

--- a/src/services/career/jobAds/operations.ts
+++ b/src/services/career/jobAds/operations.ts
@@ -35,7 +35,7 @@ export const jobAdOperations = {
         dataSchema: jobAdSchemas.create,
         authorizer: () => jobAdAuth.create.dynamicFields({}),
         operation: async ({ prisma, data: { articleName, companyId, ...data } }) => {
-            const article = await articleOperations.create({ data: { name: articleName }, bypassAuth: true })
+            const article = await articleOperations.create.internalCall({ data: { name: articleName } })
 
             return await prisma.jobAd.create({
                 data: {
@@ -159,7 +159,7 @@ export const jobAdOperations = {
             const jobAd = await prisma.jobAd.delete({
                 where: { id },
             })
-            await articleOperations.destroy({ params: { articleId: jobAd.articleId }, bypassAuth: true })
+            await articleOperations.destroy.internalCall({ params: { articleId: jobAd.articleId } })
         }
     }),
 }

--- a/src/services/career/operations.ts
+++ b/src/services/career/operations.ts
@@ -12,9 +12,8 @@ export const careerOperations = {
     updateSpecialCmsParagraphContentCareerInfo: cmsParagraphOperations.updateContent.implement({
         authorizer: () => careerAuth.updateSpecialCmsParagraphContentCareerInfo.dynamicFields({}),
         ownershipCheck: async ({ params }) =>
-            await cmsParagraphOperations.isSpecial({
+            await cmsParagraphOperations.isSpecial.internalCall({
                 params: { paragraphId: params.paragraphId, special: ['CAREER_INFO'] },
-                bypassAuth: true,
             })
     }),
 
@@ -26,7 +25,7 @@ export const careerOperations = {
     updateSpecialCmsLink: cmsLinkOperations.update.implement({
         authorizer: () => careerAuth.updateSpecialCmsLink.dynamicFields({}),
         ownershipCheck: ({ params }) =>
-            cmsLinkOperations.isSpecial({
+            cmsLinkOperations.isSpecial.internalCall({
                 params: {
                     linkId: params.linkId,
                     special: ['CAREER_LINK_TO_CONTACTOR']

--- a/src/services/education/schools/create.ts
+++ b/src/services/education/schools/create.ts
@@ -14,15 +14,13 @@ import type { CreateSchoolTypes } from './validation'
 export async function createSchool(rawdata: CreateSchoolTypes['Detailed']): Promise<SchoolFiltered> {
     const data = createSchoolValidation.detailedValidate(rawdata)
 
-    const cmsImage = await cmsImageOperations.create({
+    const cmsImage = await cmsImageOperations.create.internalCall({
         data: {},
-        bypassAuth: true
     })
-    const cmsParagraph = await cmsParagraphOperations.create({
+    const cmsParagraph = await cmsParagraphOperations.create.internalCall({
         data: {},
-        bypassAuth: true
     })
-    const cmsLink = await cmsLinkOperations.create({ data: { text: 'link', url: './' }, bypassAuth: true })
+    const cmsLink = await cmsLinkOperations.create.internalCall({ data: { text: 'link', url: './' } })
 
     return await prismaCall(() => prisma.school.create({
         data: {

--- a/src/services/events/operations.ts
+++ b/src/services/events/operations.ts
@@ -79,8 +79,8 @@ export const eventOperations = {
         dataSchema: eventSchemas.create,
         authorizer: () => eventAuth.create.dynamicFields({}),
         operation: async ({ prisma, data, session }) => {
-            const cmsParagraph = await cmsParagraphOperations.create({ data: {}, bypassAuth: true })
-            const cmsImage = await cmsImageOperations.create({ data: {}, bypassAuth: true })
+            const cmsParagraph = await cmsParagraphOperations.create.internalCall({ data: {} })
+            const cmsImage = await cmsImageOperations.create.internalCall({ data: {} })
 
             if (data.eventStart > data.eventEnd) {
                 throw new ServerError('BAD PARAMETERS', 'Event må jo strate før den slutter')
@@ -131,7 +131,7 @@ export const eventOperations = {
                 }))
             })
 
-            await notificationOperations.createSpecial({
+            await notificationOperations.createSpecial.internalCall({
                 params: {
                     special: 'NEW_EVENT',
                 },
@@ -139,7 +139,6 @@ export const eventOperations = {
                     title: `Hva der hender: ${event.name}`,
                     message: `${event.name}, 🕓 ${displayDate(event.eventStart, false)},📍 ${event.location}`,
                 },
-                bypassAuth: true,
             })
             return event
         }

--- a/src/services/events/registration/operations.ts
+++ b/src/services/events/registration/operations.ts
@@ -372,7 +372,7 @@ export const eventRegistrationOperations = {
             const message = `Gratulerer! Du har rykket opp fra venteliste på arrangementet ${registration.event.name}.`
 
             if (nextInLine.user) {
-                await notificationOperations.createSpecial({
+                await notificationOperations.createSpecial.internalCall({
                     params: {
                         special: 'EVENT_WAITINGLIST_PROMOTION',
                     },
@@ -381,7 +381,6 @@ export const eventRegistrationOperations = {
                         message,
                         userIdList: [nextInLine.user.id],
                     },
-                    bypassAuth: true,
                 })
             }
 

--- a/src/services/flairs/operations.ts
+++ b/src/services/flairs/operations.ts
@@ -187,8 +187,7 @@ export const flairOperations = {
                         id: flairId,
                     }
                 })
-                await cmsImageOperations.destroy({
-                    bypassAuth: true,
+                await cmsImageOperations.destroy.internalCall({
                     prisma: tx,
                     params: {
                         cmsImageId: flair.imageId,

--- a/src/services/frontpage/operations.ts
+++ b/src/services/frontpage/operations.ts
@@ -42,12 +42,11 @@ export const frontpageOperations = {
     updateSpecialCmsParagraphContentSection: cmsParagraphOperations.updateContent.implement({
         authorizer: () => frontpageAuth.updateSpecialCmsParagraphContentSection.dynamicFields({}),
         ownershipCheck: async ({ params }) =>
-            await cmsParagraphOperations.isSpecial({
+            await cmsParagraphOperations.isSpecial.internalCall({
                 params: {
                     paragraphId: params.paragraphId,
                     special: [...ownedCmsParagraphs],
                 },
-                bypassAuth: true
             })
     }),
 
@@ -59,12 +58,11 @@ export const frontpageOperations = {
     updateSpecialCmsImage: cmsImageOperations.update.implement({
         authorizer: () => frontpageAuth.updateSpecialCmsImage.dynamicFields({}),
         ownershipCheck: async ({ params }) =>
-            await cmsImageOperations.isSpecial({
+            await cmsImageOperations.isSpecial.internalCall({
                 params: {
                     cmsImageId: params.cmsImageId,
                     special: [...ownedCmsImages],
                 },
-                bypassAuth: true
             })
     }),
 } as const

--- a/src/services/groups/interestGroups/operations.ts
+++ b/src/services/groups/interestGroups/operations.ts
@@ -115,7 +115,7 @@ export const interestGroupOperations = {
     updateSpecialCmsParagraphContentGeneralInfo: cmsParagraphOperations.updateContent.implement({
         authorizer: () => interestGroupAuth.updateSpecialCmsParagraphContentGeneralInfo.dynamicFields({}),
         ownershipCheck: async ({ params }) =>
-            await cmsParagraphOperations.isSpecial({
+            await cmsParagraphOperations.isSpecial.internalCall({
                 params: {
                     paragraphId: params.paragraphId,
                     special: ['INTEREST_GROUP_GENERAL_INFO']

--- a/src/services/groups/memberships/create.ts
+++ b/src/services/groups/memberships/create.ts
@@ -18,8 +18,7 @@ export async function createMembershipForUser(
         throw new ServerError('BAD PARAMETERS', 'Denne Gruppetypen kan ikke enkelt opprette medlemskap')
     }
 
-    const order = orderArg ?? await groupOperations.readCurrentGroupOrder({
-        bypassAuth: true,
+    const order = orderArg ?? await groupOperations.readCurrentGroupOrder.internalCall({
         params: {
             id: groupId,
         }
@@ -64,8 +63,7 @@ export async function createMembershipsForGroup(
     if (!await canEasilyManageMembershipOfGroup(groupId)) {
         throw new ServerError('BAD PARAMETERS', 'Denne Gruppetypen kan ikke enkelt opprette medlemskap')
     }
-    const order = orderArg ?? await groupOperations.readCurrentGroupOrder({
-        bypassAuth: true,
+    const order = orderArg ?? await groupOperations.readCurrentGroupOrder.internalCall({
         params: {
             id: groupId,
         }
@@ -111,8 +109,7 @@ export async function createMembershipsForUser(
     if (!await canEasilyManageMembershipOfGroups(data.map(group => group.groupId))) {
         throw new ServerError('BAD PARAMETERS', 'Denne Gruppetypen kan ikke enkelt opprette medlemskap')
     }
-    const ordersMap = await groupOperations.readCurrentGroupOrders({
-        bypassAuth: true,
+    const ordersMap = await groupOperations.readCurrentGroupOrders.internalCall({
         params: {
             ids: data.map(group => group.groupId)
         }

--- a/src/services/groups/memberships/destroy.ts
+++ b/src/services/groups/memberships/destroy.ts
@@ -19,8 +19,7 @@ export async function destoryMembershipOfUser({
     if (!await canEasilyManageMembershipOfGroup(groupId)) {
         throw new ServerError('BAD PARAMETERS', 'Denne Gruppetypen kan ikke enkelt opprette medlemskap')
     }
-    const order = orderArg ?? await groupOperations.readCurrentGroupOrder({
-        bypassAuth: true,
+    const order = orderArg ?? await groupOperations.readCurrentGroupOrder.internalCall({
         params: {
             id: groupId
         }
@@ -47,8 +46,7 @@ export async function destroyMembershipOfUsers(
     if (!await canEasilyManageMembershipOfGroup(groupId)) {
         throw new ServerError('BAD PARAMETERS', 'Denne Gruppetypen kan ikke enkelt opprette medlemskap')
     }
-    const order = orderArg ?? await groupOperations.readCurrentGroupOrder({
-        bypassAuth: true,
+    const order = orderArg ?? await groupOperations.readCurrentGroupOrder.internalCall({
         params: {
             id: groupId,
         }

--- a/src/services/groups/memberships/update.ts
+++ b/src/services/groups/memberships/update.ts
@@ -18,8 +18,7 @@ export async function updateMembership({
     active?: boolean
 }): Promise<ExpandedMembership> {
     const order = (orderArg && typeof orderArg === 'number') ? orderArg : (
-        await groupOperations.readCurrentGroupOrder({
-            bypassAuth: true,
+        await groupOperations.readCurrentGroupOrder.internalCall({
             params: {
                 id: groupId
             }

--- a/src/services/groups/operations.ts
+++ b/src/services/groups/operations.ts
@@ -3,8 +3,7 @@ import { groupsExpandedIncluder, groupTypesConfig, OmegaMembershipLevelConfig, r
 import { groupAuth } from './auth'
 import { userFilterSelection } from '@/services/users/constants'
 import { ServerError } from '@/services/error'
-import { defineOperation } from '@/services/serviceOperation'
-import { ServerOnlyAuthorizer } from '@/auth/authorizer/RequireServer'
+import { defineOperation, defineSubOperation } from '@/services/serviceOperation'
 import { getMembershipFilter } from '@/auth/getMembershipFilter'
 import logger from '@/lib/logger'
 import { z } from 'zod'
@@ -193,12 +192,11 @@ export const groupOperations = {
         operation: async ({ prisma }) => prisma.group.findMany()
     }),
 
-    readCurrentGroupOrder: defineOperation({
-        authorizer: ServerOnlyAuthorizer,
-        paramsSchema: z.object({
+    readCurrentGroupOrder: defineSubOperation({
+        paramsSchema: () => z.object({
             id: z.number(),
         }),
-        operation: async ({ prisma, params }) => (await prisma.group.findUniqueOrThrow({
+        operation: () => async ({ prisma, params }) => (await prisma.group.findUniqueOrThrow({
             where: {
                 id: params.id,
             },
@@ -208,12 +206,11 @@ export const groupOperations = {
         })).order
     }),
 
-    readCurrentGroupOrders: defineOperation({
-        authorizer: ServerOnlyAuthorizer,
-        paramsSchema: z.object({
+    readCurrentGroupOrders: defineSubOperation({
+        paramsSchema: () => z.object({
             ids: z.number().array(),
         }),
-        operation: async ({ prisma, params }) => prisma.group.findMany({
+        operation: () => async ({ prisma, params }) => prisma.group.findMany({
             where: {
                 id: {
                     in: params.ids,
@@ -226,12 +223,11 @@ export const groupOperations = {
         })
     }),
 
-    readGroup: defineOperation({
-        authorizer: ServerOnlyAuthorizer,
-        paramsSchema: z.object({
+    readGroup: defineSubOperation({
+        paramsSchema: () => z.object({
             id: z.number(),
         }),
-        operation: async ({ prisma, params }) => prisma.group.findUniqueOrThrow({
+        operation: () => async ({ prisma, params }) => prisma.group.findUniqueOrThrow({
             where: {
                 id: params.id,
             },
@@ -305,15 +301,14 @@ export const groupOperations = {
         }
     }),
 
-    readUsersOfGroups: defineOperation({
-        authorizer: ServerOnlyAuthorizer,
-        paramsSchema: z.object({
+    readUsersOfGroups: defineSubOperation({
+        paramsSchema: () => z.object({
             groups: z.array(z.object({
                 groupId: z.number(),
                 admin: z.boolean(),
             })),
         }),
-        operation: async ({ prisma, params }): Promise<UserFiltered[]> => {
+        operation: () => async ({ prisma, params }): Promise<UserFiltered[]> => {
             const memberships = await prisma.membership.findMany({
                 where: {
                     OR: params.groups.map(({ admin, groupId }) => ({
@@ -332,12 +327,11 @@ export const groupOperations = {
         }
     }),
 
-    readGroupsOfUser: defineOperation({
-        authorizer: ServerOnlyAuthorizer,
-        paramsSchema: z.object({
+    readGroupsOfUser: defineSubOperation({
+        paramsSchema: () => z.object({
             userId: z.number(),
         }),
-        operation: async ({ prisma, params }) => {
+        operation: () => async ({ prisma, params }) => {
             const memberships = await prisma.membership.findMany({
                 where: {
                     userId: params.userId,

--- a/src/services/images/collections/create.ts
+++ b/src/services/images/collections/create.ts
@@ -10,8 +10,8 @@ export async function createImageCollection(
     rawdata: CreateImageCollectionTypes['Detailed']
 ): Promise<ImageCollection> {
     const data = createImageCollectionValidation.detailedValidate(rawdata)
-    const visibilityRead = await visibilityOperations.create({ bypassAuth: true })
-    const visibilityAdmin = await visibilityOperations.create({ bypassAuth: true })
+    const visibilityRead = await visibilityOperations.create.internalCall({})
+    const visibilityAdmin = await visibilityOperations.create.internalCall({})
 
     return await prismaCall(() => prisma.imageCollection.create({
         data: {

--- a/src/services/images/collections/destroy.ts
+++ b/src/services/images/collections/destroy.ts
@@ -21,7 +21,7 @@ export async function destroyImageCollection(collectionId: number): Promise<Imag
         },
     }))
 
-    await visibilityOperations.destroy({ params: { visibilityId: collection.visibilityAdminId }, bypassAuth: true })
-    await visibilityOperations.destroy({ params: { visibilityId: collection.visibilityReadId }, bypassAuth: true })
+    await visibilityOperations.destroy.internalCall({ params: { visibilityId: collection.visibilityAdminId } })
+    await visibilityOperations.destroy.internalCall({ params: { visibilityId: collection.visibilityReadId } })
     return collection
 }

--- a/src/services/images/collections/read.ts
+++ b/src/services/images/collections/read.ts
@@ -101,8 +101,8 @@ export async function readSpecialImageCollection(special: SpecialCollection): Pr
         //but the schema requires them to exist - believe this implementation to be better than for
         //regular collections to maybe be in invalid state with no visibility.
         // TODO: use create method.
-        const visibilityAdmin = await visibilityOperations.create({ bypassAuth: true })
-        const visibilityRead = await visibilityOperations.create({ bypassAuth: true })
+        const visibilityAdmin = await visibilityOperations.create.internalCall({})
+        const visibilityRead = await visibilityOperations.create.internalCall({})
 
         const newCollection = await prismaCall(() => prisma.imageCollection.create({
             data: {

--- a/src/services/lockers/reservations/operations.ts
+++ b/src/services/lockers/reservations/operations.ts
@@ -26,8 +26,7 @@ export const lockerReservationOperations = {
             // TODO: Use authorizers for authing in stead of this
             // Verify that user is in group
             if (data.groupId) {
-                const groupUsers = await groupOperations.readUsersOfGroups({
-                    bypassAuth: true,
+                const groupUsers = await groupOperations.readUsersOfGroups.internalCall({
                     params: {
                         groups: [{ groupId: data.groupId, admin: false }]
                     }
@@ -107,8 +106,7 @@ export const lockerReservationOperations = {
 
             // Verify that user is in group
             if (data.groupId) {
-                const groupUsers = await groupOperations.readUsersOfGroups({
-                    bypassAuth: true,
+                const groupUsers = await groupOperations.readUsersOfGroups.internalCall({
                     params: {
                         groups: [{ groupId: data.groupId, admin: false }]
                     }

--- a/src/services/news/actions.ts
+++ b/src/services/news/actions.ts
@@ -52,7 +52,7 @@ export async function publishNewsAction(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     shouldPublish: boolean
 ): Promise<ActionReturn<Omit<SimpleNewsArticle, 'coverImage'>>> {
-    notificationOperations.createSpecial({
+    notificationOperations.createSpecial.internalCall({
         params: {
             special: 'NEW_NEWS_ARTICLE',
         },
@@ -60,7 +60,6 @@ export async function publishNewsAction(
             title: 'Ny nyhetsartikkel', // TODO: Add info about the article
             message: 'En ny nyhetsartikkel er publisert',
         },
-        bypassAuth: true,
     })
 
     return createActionError('UNKNOWN ERROR', 'Not implemented')

--- a/src/services/news/operations.ts
+++ b/src/services/news/operations.ts
@@ -37,7 +37,7 @@ export const newsOperations = {
             const backupEndDateTime = new Date()
             backupEndDateTime.setDate(backupEndDateTime.getDate() + defaultNewsArticleOldCutoff)
 
-            const article = await articleOperations.create({ data: { name }, bypassAuth: true })
+            const article = await articleOperations.create.internalCall({ data: { name } })
 
             const news = await prisma.newsArticle.create({
                 data: {
@@ -63,7 +63,7 @@ export const newsOperations = {
             const news = await prisma.newsArticle.delete({
                 where: { id: params.id },
             })
-            await articleOperations.destroy({ params: { articleId: news.articleId }, bypassAuth: true })
+            await articleOperations.destroy.internalCall({ params: { articleId: news.articleId } })
         }
     }),
     readCurrent: defineOperation({

--- a/src/services/notifications/operations.ts
+++ b/src/services/notifications/operations.ts
@@ -7,8 +7,7 @@ import { availableNotificationMethodIncluder } from './channel/constants'
 import { sendMail } from './email/send'
 import { emailSchemas } from './email/schemas'
 import { userFilterSelection } from '@/services/users/constants'
-import { defineOperation } from '@/services/serviceOperation'
-import { ServerOnly } from '@/auth/authorizer/ServerOnly'
+import { defineOperation, defineSubOperation } from '@/services/serviceOperation'
 import { SpecialNotificationChannel } from '@/prisma-generated-pn-types'
 import { z } from 'zod'
 import type { Notification } from '@/prisma-generated-pn-types'
@@ -125,13 +124,12 @@ export const notificationOperations = {
      * @param message - The message content of the notification.
      * @returns A promise that resolves with an object containing the dispatched notification and the number of recipients.
      */
-    createSpecial: defineOperation({
-        authorizer: ServerOnly,
-        paramsSchema: z.object({
+    createSpecial: defineSubOperation({
+        paramsSchema: () => z.object({
             special: z.nativeEnum(SpecialNotificationChannel),
         }),
-        dataSchema: notificationSchemas.createSpecial,
-        operation: async ({ prisma, params, data, session }): Promise<NotificationResult> => {
+        dataSchema: () => notificationSchemas.createSpecial,
+        operation: () => async ({ prisma, params, data, session }): Promise<NotificationResult> => {
             const channel = await prisma.notificationChannel.findUniqueOrThrow({
                 where: {
                     special: params.special,

--- a/src/services/notifications/subscription/operations.ts
+++ b/src/services/notifications/subscription/operations.ts
@@ -5,8 +5,7 @@ import { validateMethods } from '@/services/notifications/channel/schemas'
 import { allNotificationMethodsOff, allNotificationMethodsOn } from '@/services/notifications/constants'
 import { availableNotificationMethodIncluder } from '@/services/notifications/channel/constants'
 import { notificationChannelOperations } from '@/services/notifications/channel/operations'
-import { defineOperation } from '@/services/serviceOperation'
-import { ServerOnly } from '@/auth/authorizer/ServerOnly'
+import { defineOperation, defineSubOperation } from '@/services/serviceOperation'
 import { ServerError } from '@/services/error'
 import { z } from 'zod'
 import type { Prisma } from '@/prisma-generated-pn-types'
@@ -122,13 +121,12 @@ export const notificationSubscriptionOperations = {
         }),
     }),
 
-    createDefault: defineOperation({
-        authorizer: ServerOnly,
-        paramsSchema: z.object({
+    createDefault: defineSubOperation({
+        paramsSchema: () => z.object({
             userId: z.number(),
         }),
         opensTransaction: true,
-        operation: async ({ prisma, params, session }) => {
+        operation: () => async ({ prisma, params, session }) => {
             const channels = await notificationChannelOperations.readDefault({
                 session,
                 bypassAuth: true,

--- a/src/services/ombul/operations.ts
+++ b/src/services/ombul/operations.ts
@@ -165,9 +165,8 @@ const create = defineOperation({
             },
         })
 
-        const cmsCoverImage = await cmsImageOperations.create({
+        const cmsCoverImage = await cmsImageOperations.create.internalCall({
             data: { imageId: coverImage.id },
-            bypassAuth: true
         })
 
         const ombul = await prisma.ombul.create({
@@ -184,7 +183,7 @@ const create = defineOperation({
             }
         })
 
-        notificationOperations.createSpecial({
+        notificationOperations.createSpecial.internalCall({
             params: {
                 special: 'NEW_OMBUL',
             },
@@ -192,7 +191,6 @@ const create = defineOperation({
                 title: 'Ny ombul',
                 message: `Ny ombul er ute! ${ombul.name}`,
             },
-            bypassAuth: true,
         })
 
         return ombul

--- a/src/services/omegaquotes/operations.ts
+++ b/src/services/omegaquotes/operations.ts
@@ -26,7 +26,7 @@ export const omegaquoteOperations = {
                 }
             })
 
-            notificationOperations.createSpecial({
+            notificationOperations.createSpecial.internalCall({
                 params: {
                     special: 'NEW_OMEGAQUOTE',
                 },
@@ -34,7 +34,6 @@ export const omegaquoteOperations = {
                     title: 'Ny Omegaquote♪',
                     message: `${results.quote}\n - ${results.author}`,
                 },
-                bypassAuth: true,
             })
             return results
         }

--- a/src/services/permissions/operations.ts
+++ b/src/services/permissions/operations.ts
@@ -1,7 +1,6 @@
 import '@pn-server-only'
 import { permissionsAuth } from './auth'
-import { defineOperation } from '@/services/serviceOperation'
-import { ServerOnlyAuthorizer } from '@/auth/authorizer/RequireServer'
+import { defineOperation, defineSubOperation } from '@/services/serviceOperation'
 import { invalidateAllUserSessionData, invalidateManyUserSessionData } from '@/services/auth/invalidateSession'
 import { groupsWithRelationsIncluder } from '@/services/groups/constants'
 import { checkGroupValidity, inferGroupName } from '@/services/groups/operations'
@@ -16,12 +15,11 @@ export const permissionOperations = {
             (await prisma.defaultPermission.findMany()).map(perm => perm.permission)
     }),
 
-    readPermissionsOfUser: defineOperation({
-        authorizer: ServerOnlyAuthorizer,
-        paramsSchema: z.object({
+    readPermissionsOfUser: defineSubOperation({
+        paramsSchema: () => z.object({
             userId: z.number(),
         }),
-        operation: async ({ prisma, params }) => {
+        operation: () => async ({ prisma, params }) => {
             const [defaultPermissions, groupPermissions] = await Promise.all([
                 permissionOperations.readDefaultPermissions({}),
                 prisma.membership.findMany({

--- a/src/services/screens/pages/create.ts
+++ b/src/services/screens/pages/create.ts
@@ -8,8 +8,8 @@ import type { ScreenPage } from '@/prisma-generated-pn-types'
 
 export async function createPage(rawdata: CreatePageTypes['Detailed']): Promise<ScreenPage> {
     const { name } = createPageValidation.detailedValidate(rawdata)
-    const cmsImage = await cmsImageOperations.create({ data: {}, bypassAuth: true })
-    const cmsParagraph = await cmsParagraphOperations.create({ data: {}, bypassAuth: true })
+    const cmsImage = await cmsImageOperations.create.internalCall({ data: {} })
+    const cmsParagraph = await cmsParagraphOperations.create.internalCall({ data: {} })
 
     return await prismaCall(() => prisma.screenPage.create({
         data: {

--- a/src/services/shop/purchase/operations.ts
+++ b/src/services/shop/purchase/operations.ts
@@ -26,8 +26,7 @@ export const purchaseOperations = {
                 throw e
             }
 
-            const permissions = await permissionOperations.readPermissionsOfUser({
-                bypassAuth: true,
+            const permissions = await permissionOperations.readPermissionsOfUser.internalCall({
                 params: {
                     userId: user.id,
                 },

--- a/src/services/users/operations.ts
+++ b/src/services/users/operations.ts
@@ -156,8 +156,7 @@ export const userOperations = {
             }))
 
             const memberships = await readMembershipsOfUser(user.id)
-            const permissions = await permissionOperations.readPermissionsOfUser({
-                bypassAuth: true,
+            const permissions = await permissionOperations.readPermissionsOfUser.internalCall({
                 params: {
                     userId: user.id
                 }
@@ -503,11 +502,10 @@ export const userOperations = {
             ])
 
             try {
-                await notificationSubscriptionOperations.createDefault({
+                await notificationSubscriptionOperations.createDefault.internalCall({
                     params: {
                         userId: params.id,
                     },
-                    bypassAuth: true,
                 })
             } catch (error) {
                 if (!(error instanceof ServerError) || error.errorCode !== 'DUPLICATE') {

--- a/src/services/visibility/operations.ts
+++ b/src/services/visibility/operations.ts
@@ -1,22 +1,19 @@
 import '@pn-server-only'
 import { visibilitySchemas } from './schemas'
-import { defineOperation, defineSubOperation } from '@/services/serviceOperation'
+import { defineSubOperation } from '@/services/serviceOperation'
 import { readCurrentOmegaOrder } from '@/services/omegaOrder/read'
-import { ServerOnly } from '@/auth/authorizer/ServerOnly'
 import { ServerError } from '@/services/error'
 import type { VisibilityMatrix } from './types'
 
 export const visibilityOperations = {
-    create: defineOperation({
-        authorizer: ServerOnly,
-        operation: ({ prisma }) =>
+    create: defineSubOperation({
+        operation: () => ({ prisma }) =>
             prisma.visibility.create({ data: {} })
     }),
 
-    destroy: defineOperation({
-        authorizer: ServerOnly,
-        paramsSchema: visibilitySchemas.params,
-        operation: ({ prisma, params }) =>
+    destroy: defineSubOperation({
+        paramsSchema: () => visibilitySchemas.params,
+        operation: () => ({ prisma, params }) =>
             prisma.visibility.delete({ where: { id: params.visibilityId } })
     }),
 

--- a/tests/services/serviceOperations.test.ts
+++ b/tests/services/serviceOperations.test.ts
@@ -1,8 +1,8 @@
 import { RequireNothing } from '@/auth/authorizer/RequireNothing'
-import { RequireServerOnly } from '@/auth/authorizer/ServerOnly'
 import { Session } from '@/auth/session/Session'
 import { defineOperation } from '@/services/serviceOperation'
 import { prisma as globalPrisma } from '@/prisma-pn-client-instance'
+import { AuthorizerFactory } from '@/auth/authorizer/Authorizer'
 import { describe, expect, test } from '@jest/globals'
 import { z } from 'zod'
 
@@ -11,7 +11,9 @@ describe('service operation', () => {
         const addPositiveOnly = defineOperation({
             authorizer: ({ data: { a, b } }) => {
                 if (a < 0 || b < 0) {
-                    return RequireServerOnly.staticFields({}).dynamicFields({})
+                    return AuthorizerFactory(
+                        ({ session }) => ({ success: false, session })
+                    ).staticFields({}).dynamicFields({})
                 }
 
                 return RequireNothing.staticFields({}).dynamicFields({})


### PR DESCRIPTION
## Summary

- Convert all `defineOperation` calls using `ServerOnly`/`ServerOnlyAuthorizer` as their authorizer to `defineSubOperation`
- Update all call sites that previously used `bypassAuth: true` to use `.internalCall()` instead
- Remove `ServerOnly`/`ServerOnlyAuthorizer` imports from all converted files

## Motivation

The old pattern relied on a runtime auth bypass convention (`bypassAuth: true`) to call server-internal operations. `defineSubOperation` + `.internalCall()` makes the server-only intent explicit in the type system, which is cleaner and less error-prone.

## Test plan

- [x] TypeScript check passes (`tsc --noEmit` — no errors)
- [x] Run the app locally and verify affected features work (visibility, CMS, groups, notifications, cabin booking, events, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)